### PR TITLE
Specify project dependencies in PlatformIO config

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,6 @@ monitor_speed = 115200
 debug_tool = minimodule
 debug_build_flags = -DEXTERNAL_DEBUG=1 
 
+lib_deps =
+    ArduinoSimpleLogging@0.2.2
+    IotWebConf@2.3.1


### PR DESCRIPTION
Hi Reed,

The project wasn't building after I cloned it.  I added two library dependencies to the PlatformIO config file to fix it:

https://platformio.org/lib/show/2032/ArduinoSimpleLogging
https://platformio.org/lib/show/5676/IotWebConf
