### PR TITLE
Add cache control header to HTTP responses

### DIFF
--- a/src/PluckyWebServer.cpp
+++ b/src/PluckyWebServer.cpp
@@ -70,6 +70,7 @@ bool PluckyWebServer::_handleFileRead(String path) {
     if (_webPathExists(pathWithGz)) {
       path += ".gz";
     }
+    _ws->sendHeader("Cache-Control", "max-age=604800");   // 7 days
     File file = SPIFFS.open(path, "r");
     _ws->streamFile(file, contentType);
     file.close();


### PR DESCRIPTION
Fixes #32 

Added a response header for caching.  It's set for 7 days (although I think longer might be ok too). 

Lmk what you think.